### PR TITLE
Improve tests on command module tests in Budgeting context

### DIFF
--- a/test/purse_craft/budgeting/commands/categories/delete_category_test.exs
+++ b/test/purse_craft/budgeting/commands/categories/delete_category_test.exs
@@ -11,22 +11,25 @@ defmodule PurseCraft.Budgeting.Commands.Categories.DeleteCategoryTest do
   alias PurseCraft.PubSub.BroadcastWorkspace
 
   setup do
+    user = IdentityFactory.insert(:user)
     workspace = CoreFactory.insert(:workspace)
-    category = BudgetingFactory.insert(:category, workspace_id: workspace.id)
+    category = BudgetingFactory.insert(:category, workspace: workspace)
+    scope = IdentityFactory.build(:scope, user: user)
 
-    %{
-      workspace: workspace,
-      category: category
-    }
+    {:ok, user: user, workspace: workspace, category: category, scope: scope}
   end
 
   describe "call/3" do
-    test "with owner role (authorized scope) deletes a category", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
+    test "with owner role (authorized scope) deletes a category", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
 
-      assert {:ok, %Category{}} = DeleteCategory.call(scope, workspace, category)
+      assert {:ok, deleted_category} = DeleteCategory.call(scope, workspace, category)
+      assert deleted_category.id == category.id
       assert_raise Ecto.NoResultsError, fn -> Repo.get!(Category, category.id) end
     end
 
@@ -35,7 +38,8 @@ defmodule PurseCraft.Budgeting.Commands.Categories.DeleteCategoryTest do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :editor)
       scope = IdentityFactory.build(:scope, user: user)
 
-      assert {:ok, %Category{}} = DeleteCategory.call(scope, workspace, category)
+      assert {:ok, deleted_category} = DeleteCategory.call(scope, workspace, category)
+      assert deleted_category.id == category.id
       assert_raise Ecto.NoResultsError, fn -> Repo.get!(Category, category.id) end
     end
 
@@ -59,18 +63,22 @@ defmodule PurseCraft.Budgeting.Commands.Categories.DeleteCategoryTest do
       assert Repo.get(Category, category.id)
     end
 
-    test "invokes BroadcastWorkspace when category is deleted successfully", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
+    test "broadcasts category_deleted event when category is deleted successfully", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
 
       expect(BroadcastWorkspace, :call, fn broadcast_workspace, {:category_deleted, broadcast_category} ->
-        assert broadcast_workspace == workspace
+        assert broadcast_workspace.id == workspace.id
         assert broadcast_category.id == category.id
         :ok
       end)
 
-      assert {:ok, %Category{}} = DeleteCategory.call(scope, workspace, category)
+      assert {:ok, deleted_category} = DeleteCategory.call(scope, workspace, category)
+      assert deleted_category.id == category.id
 
       verify!()
     end

--- a/test/purse_craft/budgeting/commands/categories/update_category_test.exs
+++ b/test/purse_craft/budgeting/commands/categories/update_category_test.exs
@@ -4,133 +4,109 @@ defmodule PurseCraft.Budgeting.Commands.Categories.UpdateCategoryTest do
   import Mimic
 
   alias PurseCraft.Budgeting.Commands.Categories.UpdateCategory
-  alias PurseCraft.Budgeting.Repositories.CategoryRepository
-  alias PurseCraft.Budgeting.Schemas.Category
   alias PurseCraft.BudgetingFactory
   alias PurseCraft.CoreFactory
   alias PurseCraft.IdentityFactory
   alias PurseCraft.PubSub.BroadcastWorkspace
 
   setup do
+    user = IdentityFactory.insert(:user)
     workspace = CoreFactory.insert(:workspace)
-    category = BudgetingFactory.insert(:category, workspace_id: workspace.id)
+    category = BudgetingFactory.insert(:category, workspace: workspace)
+    scope = IdentityFactory.build(:scope, user: user)
 
-    %{
-      workspace: workspace,
-      category: category
-    }
+    {:ok, user: user, workspace: workspace, category: category, scope: scope}
   end
 
-  describe "call/5" do
-    test "with string keys in attrs calls repository update correctly", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
+  describe "call/4" do
+    test "with owner role (authorized scope) updates category successfully", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
+      attrs = %{name: "Updated Category Name"}
 
-      updated_category = %{category | name: "Updated String Key Category"}
-      attrs = %{"name" => "Updated String Key Category"}
-
-      stub(CategoryRepository, :update, fn received_category, received_attrs, received_opts ->
-        assert received_category.id == category.id
-        assert received_attrs == %{name: "Updated String Key Category"}
-        assert received_opts == []
-        {:ok, updated_category}
-      end)
-
-      assert {:ok, %Category{} = result} = UpdateCategory.call(scope, workspace, category, attrs)
-      assert result.name == "Updated String Key Category"
+      assert {:ok, updated_category} = UpdateCategory.call(scope, workspace, category, attrs)
+      assert updated_category.name == "Updated Category Name"
+      assert updated_category.id == category.id
     end
 
-    test "with authorization failure returns unauthorized error", %{workspace: workspace, category: category} do
+    test "with editor role (authorized scope) updates category successfully", %{workspace: workspace, category: category} do
+      user = IdentityFactory.insert(:user)
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :editor)
+      scope = IdentityFactory.build(:scope, user: user)
+      attrs = %{name: "Editor Updated Category"}
+
+      assert {:ok, updated_category} = UpdateCategory.call(scope, workspace, category, attrs)
+      assert updated_category.name == "Editor Updated Category"
+    end
+
+    test "with commenter role (unauthorized scope) returns error", %{workspace: workspace, category: category} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :commenter)
       scope = IdentityFactory.build(:scope, user: user)
-
-      attrs = %{name: "Updated Category"}
-
-      reject(CategoryRepository, :update, 3)
+      attrs = %{name: "Commenter Category"}
 
       assert {:error, :unauthorized} = UpdateCategory.call(scope, workspace, category, attrs)
     end
 
-    test "with repository error returns changeset error", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      attrs = %{name: ""}
-      changeset = Category.changeset(category, attrs)
-
-      stub(CategoryRepository, :update, fn _category, _attrs, _opts ->
-        {:error, changeset}
-      end)
-
-      assert {:error, returned_changeset} = UpdateCategory.call(scope, workspace, category, attrs)
-      assert returned_changeset == changeset
-    end
-
-    test "with preload option preloads associations", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      updated_category = %{category | name: "Updated Category"}
-      envelope = BudgetingFactory.insert(:envelope, category_id: category.id)
-
-      stub(CategoryRepository, :update, fn _category, _attrs, received_opts ->
-        assert received_opts == [preload: [:envelopes]]
-        {:ok, %{updated_category | envelopes: [envelope]}}
-      end)
-
-      attrs = %{name: "Updated Category"}
-
-      assert {:ok, %Category{} = result} = UpdateCategory.call(scope, workspace, category, attrs, preload: [:envelopes])
-      assert result.name == "Updated Category"
-      assert Enum.any?(result.envelopes, &(&1.id == envelope.id))
-    end
-
-    test "without preload option returns category without loaded associations", %{
+    test "with no association to workspace (unauthorized scope) returns error", %{
       workspace: workspace,
       category: category
     } do
       user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
+      attrs = %{name: "Unauthorized Category"}
 
-      updated_category = %{category | name: "Updated Category"}
-
-      stub(CategoryRepository, :update, fn _category, _attrs, received_opts ->
-        assert received_opts == []
-        {:ok, updated_category}
-      end)
-
-      attrs = %{name: "Updated Category"}
-
-      assert {:ok, %Category{} = result} = UpdateCategory.call(scope, workspace, category, attrs)
-      refute Ecto.assoc_loaded?(result.envelopes)
+      assert {:error, :unauthorized} = UpdateCategory.call(scope, workspace, category, attrs)
     end
 
-    test "invokes BroadcastWorkspace with correct parameters", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
+    test "with invalid attributes returns changeset error", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
+      attrs = %{name: ""}
 
-      updated_category = %{category | name: "Broadcast Test Category"}
+      assert {:error, changeset} = UpdateCategory.call(scope, workspace, category, attrs)
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
+    end
 
-      expect(CategoryRepository, :update, fn _category, _attrs, _opts ->
-        {:ok, updated_category}
-      end)
+    test "with string keys in attrs updates category correctly", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category
+    } do
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
+      attrs = %{"name" => "String Key Updated"}
+
+      assert {:ok, updated_category} = UpdateCategory.call(scope, workspace, category, attrs)
+      assert updated_category.name == "String Key Updated"
+    end
+
+    test "broadcasts category_updated event when category is updated successfully", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category
+    } do
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
 
       expect(BroadcastWorkspace, :call, fn received_workspace, {:category_updated, received_category} ->
         assert received_workspace.id == workspace.id
-        assert received_category.id == updated_category.id
         assert received_category.name == "Broadcast Test Category"
         :ok
       end)
 
       attrs = %{name: "Broadcast Test Category"}
 
-      assert {:ok, %Category{}} = UpdateCategory.call(scope, workspace, category, attrs)
+      assert {:ok, updated_category} = UpdateCategory.call(scope, workspace, category, attrs)
+      assert updated_category.name == "Broadcast Test Category"
 
       verify!()
     end

--- a/test/purse_craft/budgeting/commands/envelopes/create_envelope_test.exs
+++ b/test/purse_craft/budgeting/commands/envelopes/create_envelope_test.exs
@@ -4,7 +4,6 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelopeTest do
   import Mimic
 
   alias PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelope
-  alias PurseCraft.Budgeting.Repositories.EnvelopeRepository
   alias PurseCraft.Budgeting.Schemas.Envelope
   alias PurseCraft.BudgetingFactory
   alias PurseCraft.CoreFactory
@@ -27,20 +26,12 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelopeTest do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "String Key Envelope", category_id: category.id}
-
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> nil end)
-
-      stub(EnvelopeRepository, :create, fn attrs ->
-        assert attrs.name == "String Key Envelope"
-        assert attrs.category_id == category.id
-        assert attrs.position == "m"
-        {:ok, envelope}
-      end)
-
       attrs = %{"name" => "String Key Envelope"}
 
-      assert {:ok, ^envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert {:ok, %Envelope{} = envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert envelope.name == "String Key Envelope"
+      assert envelope.category_id == category.id
+      assert envelope.position == "m"
     end
 
     test "with invalid data returns error changeset", %{workspace: workspace, category: category} do
@@ -48,17 +39,10 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelopeTest do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      changeset = %Ecto.Changeset{valid?: false}
-
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> nil end)
-
-      stub(EnvelopeRepository, :create, fn _attrs ->
-        {:error, changeset}
-      end)
-
       attrs = %{name: ""}
 
-      assert {:error, ^changeset} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert {:error, changeset} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
     end
 
     test "with owner role (authorized scope) creates an envelope", %{workspace: workspace, category: category} do
@@ -66,20 +50,11 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelopeTest do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "Owner Envelope", category_id: category.id}
-
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> nil end)
-
-      stub(EnvelopeRepository, :create, fn attrs ->
-        assert attrs.name == "Owner Envelope"
-        assert attrs.category_id == category.id
-        assert attrs.position == "m"
-        {:ok, envelope}
-      end)
-
       attrs = %{name: "Owner Envelope"}
 
-      assert {:ok, ^envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert {:ok, %Envelope{} = envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert envelope.name == "Owner Envelope"
+      assert envelope.category_id == category.id
     end
 
     test "with editor role (authorized scope) creates an envelope", %{workspace: workspace, category: category} do
@@ -87,20 +62,11 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelopeTest do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :editor)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "Editor Envelope", category_id: category.id}
-
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> nil end)
-
-      stub(EnvelopeRepository, :create, fn attrs ->
-        assert attrs.name == "Editor Envelope"
-        assert attrs.category_id == category.id
-        assert attrs.position == "m"
-        {:ok, envelope}
-      end)
-
       attrs = %{name: "Editor Envelope"}
 
-      assert {:ok, ^envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert {:ok, %Envelope{} = envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert envelope.name == "Editor Envelope"
+      assert envelope.category_id == category.id
     end
 
     test "with commenter role (unauthorized scope) returns error", %{workspace: workspace, category: category} do
@@ -125,53 +91,79 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.CreateEnvelopeTest do
       assert {:error, :unauthorized} = CreateEnvelope.call(scope, workspace, category, attrs)
     end
 
-    test "invokes BroadcastWorkspace when envelope is created successfully", %{workspace: workspace, category: category} do
+    test "broadcasts envelope_created event when envelope is created successfully", %{
+      workspace: workspace,
+      category: category
+    } do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "Broadcast Test Envelope", category_id: category.id}
-
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> nil end)
-
-      stub(EnvelopeRepository, :create, fn _attrs -> {:ok, envelope} end)
-
-      expect(BroadcastWorkspace, :call, fn ^workspace, {:envelope_created, ^envelope} -> :ok end)
+      expect(BroadcastWorkspace, :call, fn broadcast_workspace, {:envelope_created, broadcast_envelope} ->
+        assert broadcast_workspace.id == workspace.id
+        assert broadcast_envelope.name == "Broadcast Test Envelope"
+        :ok
+      end)
 
       attrs = %{name: "Broadcast Test Envelope"}
 
-      assert {:ok, ^envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert {:ok, %Envelope{}} = CreateEnvelope.call(scope, workspace, category, attrs)
 
       verify!()
     end
 
-    test "assigns position before existing envelope", %{workspace: workspace, category: category} do
+    test "assigns position 'm' for first envelope in a category", %{workspace: workspace, category: category} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "New Envelope", category_id: category.id}
+      attrs = %{name: "First Envelope"}
 
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> "m" end)
-
-      stub(EnvelopeRepository, :create, fn attrs ->
-        assert attrs.position == "g"
-        {:ok, envelope}
-      end)
-
-      attrs = %{name: "New Envelope"}
-
-      assert {:ok, ^envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert {:ok, %Envelope{} = envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert envelope.position == "m"
     end
 
-    test "returns error when cannot place at top", %{workspace: workspace, category: category} do
+    test "assigns position before existing envelopes", %{workspace: workspace, category: category} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      stub(EnvelopeRepository, :get_first_position, fn _category_id -> "a" end)
+      # Create first envelope
+      BudgetingFactory.insert(:envelope, category_id: category.id, position: "m")
 
-      attrs = %{name: "New Envelope"}
+      attrs = %{name: "Second Envelope"}
+
+      assert {:ok, %Envelope{} = envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert envelope.position < "m"
+      assert envelope.position == "g"
+    end
+
+    test "handles multiple envelopes being added at the top", %{workspace: workspace, category: category} do
+      user = IdentityFactory.insert(:user)
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
+      scope = IdentityFactory.build(:scope, user: user)
+
+      # Create initial envelopes
+      BudgetingFactory.insert(:envelope, category_id: category.id, position: "g")
+      BudgetingFactory.insert(:envelope, category_id: category.id, position: "m")
+      BudgetingFactory.insert(:envelope, category_id: category.id, position: "t")
+
+      attrs = %{name: "New Top Envelope"}
+
+      assert {:ok, %Envelope{} = envelope} = CreateEnvelope.call(scope, workspace, category, attrs)
+      assert envelope.position < "g"
+      assert envelope.position == "d"
+    end
+
+    test "returns error when first envelope is already at 'a'", %{workspace: workspace, category: category} do
+      user = IdentityFactory.insert(:user)
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
+      scope = IdentityFactory.build(:scope, user: user)
+
+      # Create an envelope at the boundary
+      BudgetingFactory.insert(:envelope, category_id: category.id, position: "a")
+
+      attrs = %{name: "Cannot Place At Top"}
 
       assert {:error, :cannot_place_at_top} = CreateEnvelope.call(scope, workspace, category, attrs)
     end

--- a/test/purse_craft/budgeting/commands/envelopes/delete_envelope_test.exs
+++ b/test/purse_craft/budgeting/commands/envelopes/delete_envelope_test.exs
@@ -4,35 +4,40 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.DeleteEnvelopeTest do
   import Mimic
 
   alias PurseCraft.Budgeting.Commands.Envelopes.DeleteEnvelope
-  alias PurseCraft.Budgeting.Repositories.EnvelopeRepository
+  alias PurseCraft.Budgeting.Schemas.Envelope
   alias PurseCraft.BudgetingFactory
   alias PurseCraft.CoreFactory
   alias PurseCraft.IdentityFactory
   alias PurseCraft.PubSub.BroadcastWorkspace
 
   setup do
+    user = IdentityFactory.insert(:user)
     workspace = CoreFactory.insert(:workspace)
     category = BudgetingFactory.insert(:category, workspace_id: workspace.id)
     envelope = BudgetingFactory.insert(:envelope, category_id: category.id)
+    scope = IdentityFactory.build(:scope, user: user)
 
     %{
+      user: user,
       workspace: workspace,
       category: category,
-      envelope: envelope
+      envelope: envelope,
+      scope: scope
     }
   end
 
   describe "call/3" do
-    test "with owner role (authorized scope) deletes an envelope", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
+    test "with owner role (authorized scope) deletes an envelope", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      envelope: envelope
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
 
-      stub(EnvelopeRepository, :delete, fn ^envelope ->
-        {:ok, envelope}
-      end)
-
-      assert {:ok, ^envelope} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert {:ok, deleted_envelope} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert deleted_envelope.id == envelope.id
+      assert_raise Ecto.NoResultsError, fn -> Repo.get!(Envelope, envelope.id) end
     end
 
     test "with editor role (authorized scope) deletes an envelope", %{workspace: workspace, envelope: envelope} do
@@ -40,11 +45,9 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.DeleteEnvelopeTest do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :editor)
       scope = IdentityFactory.build(:scope, user: user)
 
-      stub(EnvelopeRepository, :delete, fn ^envelope ->
-        {:ok, envelope}
-      end)
-
-      assert {:ok, ^envelope} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert {:ok, deleted_envelope} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert deleted_envelope.id == envelope.id
+      assert_raise Ecto.NoResultsError, fn -> Repo.get!(Envelope, envelope.id) end
     end
 
     test "with commenter role (unauthorized scope) returns error", %{workspace: workspace, envelope: envelope} do
@@ -53,6 +56,7 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.DeleteEnvelopeTest do
       scope = IdentityFactory.build(:scope, user: user)
 
       assert {:error, :unauthorized} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert Repo.get(Envelope, envelope.id)
     end
 
     test "with no association to workspace (unauthorized scope) returns error", %{
@@ -63,32 +67,25 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.DeleteEnvelopeTest do
       scope = IdentityFactory.build(:scope, user: user)
 
       assert {:error, :unauthorized} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert Repo.get(Envelope, envelope.id)
     end
 
-    test "with database error returns error changeset", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
+    test "broadcasts envelope_deleted event when envelope is deleted successfully", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      envelope: envelope
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
 
-      changeset = %Ecto.Changeset{valid?: false}
-
-      stub(EnvelopeRepository, :delete, fn ^envelope ->
-        {:error, changeset}
+      expect(BroadcastWorkspace, :call, fn broadcast_workspace, {:envelope_deleted, broadcast_envelope} ->
+        assert broadcast_workspace.id == workspace.id
+        assert broadcast_envelope.id == envelope.id
+        :ok
       end)
 
-      assert {:error, ^changeset} = DeleteEnvelope.call(scope, workspace, envelope)
-    end
-
-    test "invokes BroadcastWorkspace when envelope is deleted successfully", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      stub(EnvelopeRepository, :delete, fn ^envelope -> {:ok, envelope} end)
-
-      expect(BroadcastWorkspace, :call, fn ^workspace, {:envelope_deleted, ^envelope} -> :ok end)
-
-      assert {:ok, ^envelope} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert {:ok, deleted_envelope} = DeleteEnvelope.call(scope, workspace, envelope)
+      assert deleted_envelope.id == envelope.id
 
       verify!()
     end

--- a/test/purse_craft/budgeting/commands/envelopes/fetch_envelope_by_external_id_test.exs
+++ b/test/purse_craft/budgeting/commands/envelopes/fetch_envelope_by_external_id_test.exs
@@ -1,139 +1,100 @@
 defmodule PurseCraft.Budgeting.Commands.Envelopes.FetchEnvelopeByExternalIdTest do
   use PurseCraft.DataCase, async: true
 
-  import Mimic
-
   alias PurseCraft.Budgeting.Commands.Envelopes.FetchEnvelopeByExternalId
-  alias PurseCraft.Budgeting.Repositories.EnvelopeRepository
-  alias PurseCraft.Budgeting.Schemas.Envelope
   alias PurseCraft.BudgetingFactory
   alias PurseCraft.CoreFactory
   alias PurseCraft.IdentityFactory
 
   setup do
+    user = IdentityFactory.insert(:user)
     workspace = CoreFactory.insert(:workspace)
     category = BudgetingFactory.insert(:category, workspace_id: workspace.id)
+    envelope = BudgetingFactory.insert(:envelope, category_id: category.id)
+    scope = IdentityFactory.build(:scope, user: user)
 
     %{
+      user: user,
       workspace: workspace,
-      category: category
+      category: category,
+      envelope: envelope,
+      scope: scope
     }
   end
 
   describe "call/4" do
-    test "with owner role (authorized scope) returns envelope", %{workspace: workspace, category: category} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      envelope = %Envelope{id: 1, name: "Test Envelope", category_id: category.id, external_id: Ecto.UUID.generate()}
-
-      stub(EnvelopeRepository, :get_by_external_id_and_workspace_id, fn external_id, workspace_id, _opts ->
-        assert external_id == envelope.external_id
-        assert workspace_id == workspace.id
-        envelope
-      end)
-
-      assert {:ok, ^envelope} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
-    end
-
-    test "with preload option returns envelope with preloaded associations", %{
+    test "with owner role (authorized scope) returns envelope", %{
+      user: user,
+      scope: scope,
       workspace: workspace,
-      category: category
+      envelope: envelope
     } do
-      user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{
-        id: 1,
-        name: "Test Envelope",
-        category_id: category.id,
-        external_id: Ecto.UUID.generate(),
-        category: category
-      }
-
-      stub(EnvelopeRepository, :get_by_external_id_and_workspace_id, fn external_id, workspace_id, opts ->
-        assert external_id == envelope.external_id
-        assert workspace_id == workspace.id
-        assert opts == [preload: [:category]]
-        envelope
-      end)
-
-      assert {:ok, ^envelope} =
-               FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id, preload: [:category])
+      assert {:ok, fetched_envelope} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
+      assert fetched_envelope.id == envelope.id
+      assert fetched_envelope.external_id == envelope.external_id
     end
 
-    test "with invalid external_id returns not found error", %{workspace: workspace} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      external_id = Ecto.UUID.generate()
-
-      stub(EnvelopeRepository, :get_by_external_id_and_workspace_id, fn ^external_id, _workspace_id, _opts ->
-        nil
-      end)
-
-      assert {:error, :not_found} = FetchEnvelopeByExternalId.call(scope, workspace, external_id)
-    end
-
-    test "with editor role (authorized scope) returns envelope", %{workspace: workspace, category: category} do
+    test "with editor role (authorized scope) returns envelope", %{workspace: workspace, envelope: envelope} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :editor)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "Editor Envelope", category_id: category.id, external_id: Ecto.UUID.generate()}
-
-      stub(EnvelopeRepository, :get_by_external_id_and_workspace_id, fn _external_id, _workspace_id, _opts ->
-        envelope
-      end)
-
-      assert {:ok, ^envelope} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
+      assert {:ok, fetched_envelope} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
+      assert fetched_envelope.id == envelope.id
     end
 
-    test "with commenter role (authorized scope) returns envelope", %{workspace: workspace, category: category} do
+    test "with commenter role (authorized scope) returns envelope", %{workspace: workspace, envelope: envelope} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :commenter)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{id: 1, name: "Commenter Envelope", category_id: category.id, external_id: Ecto.UUID.generate()}
-
-      stub(EnvelopeRepository, :get_by_external_id_and_workspace_id, fn _external_id, _workspace_id, _opts ->
-        envelope
-      end)
-
-      assert {:ok, ^envelope} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
+      assert {:ok, fetched_envelope} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
+      assert fetched_envelope.id == envelope.id
     end
 
-    test "with no association to workspace (unauthorized scope) returns error", %{workspace: workspace} do
+    test "with no association to workspace (unauthorized scope) returns error", %{
+      workspace: workspace,
+      envelope: envelope
+    } do
       user = IdentityFactory.insert(:user)
       scope = IdentityFactory.build(:scope, user: user)
 
-      external_id = Ecto.UUID.generate()
-
-      assert {:error, :unauthorized} = FetchEnvelopeByExternalId.call(scope, workspace, external_id)
+      assert {:error, :unauthorized} = FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id)
     end
 
-    test "with envelope from different workspace returns not found", %{category: category} do
+    test "with invalid external_id returns not found error", %{user: user, scope: scope, workspace: workspace} do
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
+      invalid_external_id = Ecto.UUID.generate()
+
+      assert {:error, :not_found} = FetchEnvelopeByExternalId.call(scope, workspace, invalid_external_id)
+    end
+
+    test "with preload option returns envelope with preloaded associations", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      category: category,
+      envelope: envelope
+    } do
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
+
+      assert {:ok, fetched_envelope} =
+               FetchEnvelopeByExternalId.call(scope, workspace, envelope.external_id, preload: [:category])
+
+      assert fetched_envelope.id == envelope.id
+      assert Ecto.assoc_loaded?(fetched_envelope.category)
+      assert fetched_envelope.category.id == category.id
+    end
+
+    test "with envelope from different workspace returns not found", %{envelope: envelope} do
       different_workspace = CoreFactory.insert(:workspace)
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: different_workspace.id, user_id: user.id, role: :owner)
       scope = IdentityFactory.build(:scope, user: user)
 
-      envelope = %Envelope{
-        id: 1,
-        name: "Different Workspace Envelope",
-        category_id: category.id,
-        external_id: Ecto.UUID.generate()
-      }
-
-      stub(EnvelopeRepository, :get_by_external_id_and_workspace_id, fn external_id, workspace_id, _opts ->
-        assert external_id == envelope.external_id
-        assert workspace_id == different_workspace.id
-        nil
-      end)
-
+      # The envelope exists but belongs to a different workspace
       assert {:error, :not_found} = FetchEnvelopeByExternalId.call(scope, different_workspace, envelope.external_id)
     end
   end

--- a/test/purse_craft/budgeting/commands/envelopes/update_envelope_test.exs
+++ b/test/purse_craft/budgeting/commands/envelopes/update_envelope_test.exs
@@ -4,98 +4,57 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.UpdateEnvelopeTest do
   import Mimic
 
   alias PurseCraft.Budgeting.Commands.Envelopes.UpdateEnvelope
-  alias PurseCraft.Budgeting.Repositories.EnvelopeRepository
   alias PurseCraft.BudgetingFactory
   alias PurseCraft.CoreFactory
   alias PurseCraft.IdentityFactory
   alias PurseCraft.PubSub.BroadcastWorkspace
 
   setup do
+    user = IdentityFactory.insert(:user)
     workspace = CoreFactory.insert(:workspace)
     category = BudgetingFactory.insert(:category, workspace_id: workspace.id)
     envelope = BudgetingFactory.insert(:envelope, category_id: category.id)
+    scope = IdentityFactory.build(:scope, user: user)
 
     %{
+      user: user,
       workspace: workspace,
       category: category,
-      envelope: envelope
+      envelope: envelope,
+      scope: scope
     }
   end
 
   describe "call/4" do
-    test "with string keys in attrs updates an envelope correctly", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
+    test "with owner role (authorized scope) updates envelope successfully", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      envelope: envelope
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
+      attrs = %{name: "Updated Envelope Name"}
 
-      updated_envelope = %{envelope | name: "String Key Updated Envelope"}
-
-      stub(EnvelopeRepository, :update, fn ^envelope, attrs ->
-        assert attrs.name == "String Key Updated Envelope"
-        {:ok, updated_envelope}
-      end)
-
-      attrs = %{"name" => "String Key Updated Envelope"}
-
-      assert {:ok, ^updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert {:ok, updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert updated_envelope.name == "Updated Envelope Name"
+      assert updated_envelope.id == envelope.id
     end
 
-    test "with invalid data returns error changeset", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      changeset = %Ecto.Changeset{valid?: false}
-
-      stub(EnvelopeRepository, :update, fn ^envelope, _attrs ->
-        {:error, changeset}
-      end)
-
-      attrs = %{name: ""}
-
-      assert {:error, ^changeset} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
-    end
-
-    test "with owner role (authorized scope) updates an envelope", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
-      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
-
-      updated_envelope = %{envelope | name: "Owner Updated Envelope"}
-
-      stub(EnvelopeRepository, :update, fn ^envelope, attrs ->
-        assert attrs.name == "Owner Updated Envelope"
-        {:ok, updated_envelope}
-      end)
-
-      attrs = %{name: "Owner Updated Envelope"}
-
-      assert {:ok, ^updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
-    end
-
-    test "with editor role (authorized scope) updates an envelope", %{workspace: workspace, envelope: envelope} do
+    test "with editor role (authorized scope) updates envelope successfully", %{workspace: workspace, envelope: envelope} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :editor)
       scope = IdentityFactory.build(:scope, user: user)
-
-      updated_envelope = %{envelope | name: "Editor Updated Envelope"}
-
-      stub(EnvelopeRepository, :update, fn ^envelope, attrs ->
-        assert attrs.name == "Editor Updated Envelope"
-        {:ok, updated_envelope}
-      end)
-
       attrs = %{name: "Editor Updated Envelope"}
 
-      assert {:ok, ^updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert {:ok, updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert updated_envelope.name == "Editor Updated Envelope"
     end
 
     test "with commenter role (unauthorized scope) returns error", %{workspace: workspace, envelope: envelope} do
       user = IdentityFactory.insert(:user)
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :commenter)
       scope = IdentityFactory.build(:scope, user: user)
-
-      attrs = %{name: "Commenter Updated Envelope"}
+      attrs = %{name: "Commenter Envelope"}
 
       assert {:error, :unauthorized} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
     end
@@ -106,26 +65,55 @@ defmodule PurseCraft.Budgeting.Commands.Envelopes.UpdateEnvelopeTest do
     } do
       user = IdentityFactory.insert(:user)
       scope = IdentityFactory.build(:scope, user: user)
-
-      attrs = %{name: "Unauthorized Updated Envelope"}
+      attrs = %{name: "Unauthorized Envelope"}
 
       assert {:error, :unauthorized} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
     end
 
-    test "invokes BroadcastWorkspace when envelope is updated successfully", %{workspace: workspace, envelope: envelope} do
-      user = IdentityFactory.insert(:user)
+    test "with invalid attributes returns changeset error", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      envelope: envelope
+    } do
       CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
-      scope = IdentityFactory.build(:scope, user: user)
+      attrs = %{name: ""}
 
-      updated_envelope = %{envelope | name: "Broadcast Test Updated Envelope"}
+      assert {:error, changeset} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
+    end
 
-      stub(EnvelopeRepository, :update, fn ^envelope, _attrs -> {:ok, updated_envelope} end)
+    test "with string keys in attrs updates envelope correctly", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      envelope: envelope
+    } do
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
+      attrs = %{"name" => "String Key Updated"}
 
-      expect(BroadcastWorkspace, :call, fn ^workspace, {:envelope_updated, ^updated_envelope} -> :ok end)
+      assert {:ok, updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert updated_envelope.name == "String Key Updated"
+    end
 
-      attrs = %{name: "Broadcast Test Updated Envelope"}
+    test "broadcasts envelope_updated event when envelope is updated successfully", %{
+      user: user,
+      scope: scope,
+      workspace: workspace,
+      envelope: envelope
+    } do
+      CoreFactory.insert(:workspace_user, workspace_id: workspace.id, user_id: user.id, role: :owner)
 
-      assert {:ok, ^updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      expect(BroadcastWorkspace, :call, fn received_workspace, {:envelope_updated, received_envelope} ->
+        assert received_workspace.id == workspace.id
+        assert received_envelope.name == "Broadcast Test Envelope"
+        :ok
+      end)
+
+      attrs = %{name: "Broadcast Test Envelope"}
+
+      assert {:ok, updated_envelope} = UpdateEnvelope.call(scope, workspace, envelope, attrs)
+      assert updated_envelope.name == "Broadcast Test Envelope"
 
       verify!()
     end


### PR DESCRIPTION
I went way too hard on the mocking. This reduces the mocking greatly, but the tests are now limited to the business logic of the command modules and skipping over all of the repository-specific stuff.